### PR TITLE
MT game translation - 'intllib' is dead? Long live 'intllib' ...

### DIFF
--- a/lib/intllib.lua
+++ b/lib/intllib.lua
@@ -1,3 +1,87 @@
+-- intllib.lua
+-- should be copied from ../intllib/lib/intllib.lua   (2019-05-15)
+
+-- The MT 5 function minetest.get_translator may be a better solution.
+
+-- Fallback functions for when `intllib` is not installed.
+-- Code released under minetest-mods/intllib/LICENSE.md -- LGPLv2.1+
+
+-- Minetest Game Translation
+-- Copyright (2017-18) Diego Martínez (kaeza).
+-- Copyright (2019) snoopy (Zweihorn) & kaeza & MT Game Developers.
+
+
+local gettext, ngettext
+
+-- Check if intllib should be activated or not in the first place.
+-- The MT 5 function minetest.get_translator may be a better solution.
+-- However, it is unclear when the MT 5 scheme will be truly in place.
+
+local setactive = false
+local i = minetest.settings:get("intllib")
+if i and i ~= "" then
+	if i == "true" or i == "TRUE" then
+		setactive = true
+	end
+end
+
+-- Use the MT function minetest.get_translator if intllib is off.
+
+if not setactive and minetest.get_translator then
+
+	gettext, ngettext = minetest.get_translator()
+
+else
+
+-- When possible use make_gettext_pair from game_intllib if installed.
+
+    if minetest.get_modpath("intllib") then
+
+		if intllib.make_gettext_pair then
+			-- New method using gettext compliant to GNU gettext tool.
+			gettext, ngettext = intllib.make_gettext_pair()
+		else
+			-- The poor old method using text files.
+			gettext = intllib.Getter()
+		end
+
+    else
+
+    -- Fallback to handle a S("string") enclosure if not installed.
+
+		local function format(str, ...)
+			local args = { ... }
+			local function repl(escape, open, num, close)
+				if escape == "" then
+					local replacement = tostring(args[tonumber(num)])
+					if open == "" then
+						replacement = replacement..close
+					end
+					return replacement
+				else
+					return "@"..open..num..close
+				end
+			end
+			return (str:gsub("(@?)@(%(?)(%d+)(%)?)", repl))
+		end
+
+	-- Fill in missing functions if game_intllib is not installed.
+
+    	gettext = function(msgid, ...)
+	    	return format(msgid, ...)
+    	end
+
+    	ngettext = function(msgid, msgid_plural, n, ...)
+	    	return format(n==1 and msgid or msgid_plural, ...)
+    	end
+    end
+end
+
+return gettext, ngettext
+
+
+
+--[[
 
 -- Fallback functions for when `intllib` is not installed.
 -- Code released under Unlicense <http://unlicense.org>.
@@ -43,3 +127,6 @@ ngettext = ngettext or function(msgid, msgid_plural, n, ...)
 end
 
 return gettext, ngettext
+
+--]]
+

--- a/lib/intllib.lua
+++ b/lib/intllib.lua
@@ -1,20 +1,20 @@
 -- intllib.lua
 -- should be copied from ../intllib/lib/intllib.lua   (2019-05-15)
 
--- The MT 5 function minetest.get_translator may be a better solution.
+-- Since 5.0.0 the MT function `minetest.get_translator` is provided.
 
 -- Fallback functions for when `intllib` is not installed.
 -- Code released under minetest-mods/intllib/LICENSE.md -- LGPLv2.1+
 
--- Minetest Game Translation
+-- This is a Minetest Game Translation community effort.
 -- Copyright (2017-18) Diego Martínez (kaeza).
 -- Copyright (2019) snoopy (Zweihorn) & kaeza & MT Game Developers.
 
 
 local gettext, ngettext
 
--- Check if intllib should be activated or not in the first place.
--- The MT 5 function minetest.get_translator may be a better solution.
+-- Check if `intllib` should be activated or not in the first place.
+-- The MT function `minetest.get_translator` may be a better solution.
 -- However, it is unclear when the MT 5 scheme will be truly in place.
 
 local setactive = false
@@ -25,7 +25,7 @@ if i and i ~= "" then
 	end
 end
 
--- Use the MT function minetest.get_translator if intllib is off.
+-- Use the MT function `minetest.get_translator` if `intllib` is off.
 
 if not setactive and minetest.get_translator then
 
@@ -33,7 +33,7 @@ if not setactive and minetest.get_translator then
 
 else
 
--- When possible use make_gettext_pair from game_intllib if installed.
+-- When possible use `make_gettext_pair` from `intllib` if installed.
 
     if minetest.get_modpath("intllib") then
 
@@ -47,7 +47,7 @@ else
 
     else
 
-    -- Fallback to handle a S("string") enclosure if not installed.
+    -- Fallback to handle a `S("string")` enclosure if not installed.
 
 		local function format(str, ...)
 			local args = { ... }
@@ -65,7 +65,7 @@ else
 			return (str:gsub("(@?)@(%(?)(%d+)(%)?)", repl))
 		end
 
-	-- Fill in missing functions if game_intllib is not installed.
+	-- Fill in missing functions if `intllib` is not installed.
 
     	gettext = function(msgid, ...)
 	    	return format(msgid, ...)
@@ -78,55 +78,3 @@ else
 end
 
 return gettext, ngettext
-
-
-
---[[
-
--- Fallback functions for when `intllib` is not installed.
--- Code released under Unlicense <http://unlicense.org>.
-
--- Get the latest version of this file at:
---   https://raw.githubusercontent.com/minetest-mods/intllib/master/lib/intllib.lua
-
-local function format(str, ...)
-	local args = { ... }
-	local function repl(escape, open, num, close)
-		if escape == "" then
-			local replacement = tostring(args[tonumber(num)])
-			if open == "" then
-				replacement = replacement..close
-			end
-			return replacement
-		else
-			return "@"..open..num..close
-		end
-	end
-	return (str:gsub("(@?)@(%(?)(%d+)(%)?)", repl))
-end
-
-local gettext, ngettext
-if minetest.get_modpath("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		gettext, ngettext = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		gettext = intllib.Getter()
-	end
-end
-
--- Fill in missing functions.
-
-gettext = gettext or function(msgid, ...)
-	return format(msgid, ...)
-end
-
-ngettext = ngettext or function(msgid, msgid_plural, n, ...)
-	return format(n==1 and msgid or msgid_plural, ...)
-end
-
-return gettext, ngettext
-
---]]
-


### PR DESCRIPTION
Change to a address the MT5 game `minetest.get_translator()` function. Check if **intllib** should be activated or not in the first place. The MT 5 function minetest.get_translator may be a better solution. However, IMHO it is unclear when the MT 5 scheme will be truly in place.

Please have a look at my MT game Pull request as: [Add support for MT 5 game translation #2364](https://github.com/minetest/minetest_game/pull/2364)

> N.B. My family and me are enjoying the results of your coding efforts at home for a long time now.
> 
> I would like to thank all of the MT developers and certainly @kaeza for 'intllib' which gave me the idea and the motivation for this contribution.
> 
> [snoopy (Zweihorn)] 2019-05-13

Thank you for your consideration and certainly your good efforts.
[snoopy (Zweihorn)] 2019-05-15