### PR TITLE
Add `modname.lang.tr` locales support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -201,7 +201,8 @@ function intllib.get_strings(modname, langcode)
 		local modpath = minetest.get_modpath(modname)
 		msgstr = { }
 		for _, l in ipairs(get_locales(langcode)) do
-			local t = intllib.load_strings(modpath.."/locale/"..l..".txt") or { }
+			local t = intllib.load_strings(modpath.."/locale/"..modname.."."..l..".tr")
+				or intllib.load_strings(modpath.."/locale/"..l..".txt") or { }
 			for k, v in pairs(t) do
 				msgstr[k] = msgstr[k] or v
 			end


### PR DESCRIPTION
This will help some mods quickly switch to the new (MT5) translation API. mobs_redo is one such mod.

This patch enough for supporting `my_mod.es.tr` translation file.